### PR TITLE
INFRA-4654: Allow per rule `nogo` customization

### DIFF
--- a/go/private/context.bzl
+++ b/go/private/context.bzl
@@ -375,6 +375,8 @@ def go_context(ctx, attr = None):
         go_config_info = attr._go_config[GoConfigInfo]
     if hasattr(attr, "_stdlib"):
         stdlib = attr._stdlib[GoStdLib]
+    if getattr(attr, "nogo", None):
+        nogo = ctx.files.nogo[0] if ctx.files.nogo else None
 
     mode = get_mode(ctx, toolchain, cgo_context_info, go_config_info)
     tags = mode.tags

--- a/go/private/rules/binary.bzl
+++ b/go/private/rules/binary.bzl
@@ -357,6 +357,11 @@ _go_binary_kwargs = {
             </ul>
             """,
         ),
+        "nogo": attr.label(
+            doc = """
+            Custom nogo checker for rule.
+            """,
+        ),
         "_go_context_data": attr.label(default = "//:go_context_data"),
     },
     "executable": True,

--- a/go/private/rules/library.bzl
+++ b/go/private/rules/library.bzl
@@ -163,6 +163,11 @@ go_library = rule(
             Subject to ["Make variable"] substitution and [Bourne shell tokenization]. Only valid if `cgo = True`.
             """,
         ),
+        "nogo": attr.label(
+            doc = """
+            Custom nogo checker for rule.
+            """,
+        ),
         "_go_context_data": attr.label(default = "//:go_context_data"),
     },
     toolchains = ["@io_bazel_rules_go//go:toolchain"],

--- a/go/private/rules/test.bzl
+++ b/go/private/rules/test.bzl
@@ -392,6 +392,11 @@ _go_test_kwargs = {
             See [Cross compilation] for more information.
             """,
         ),
+        "nogo": attr.label(
+            doc = """
+            Custom nogo checker for rule.
+            """,
+        ),
         "_go_context_data": attr.label(default = "//:go_context_data"),
         "_testmain_additional_deps": attr.label_list(
             providers = [GoLibrary],


### PR DESCRIPTION
После этого можно будет указать атрибут `nogo` непосредственно в правилах и тем самым переопределить глобальный.
Так же можно отключить `nogo` указав фрагмент:
```
    nogo = "@io_bazel_rules_go//:default_nogo",
```